### PR TITLE
Bug fix in `Decoder::expand_strip` + greatly improved performance for 16 bit images

### DIFF
--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -422,7 +422,8 @@ impl<R: Read + Seek> Decoder<R> {
             (ColorType:: RGB(8), DecodingBuffer::U8(ref mut buffer)) |
             (ColorType::RGBA(8), DecodingBuffer::U8(ref mut buffer)) | 
             (ColorType::CMYK(8), DecodingBuffer::U8(ref mut buffer)) => {
-                try!(reader.read(&mut buffer[..bytes]))
+                try!(reader.read_exact(&mut buffer[..bytes]));
+                bytes
             }
             (ColorType::RGBA(16), DecodingBuffer::U16(ref mut buffer)) |
             (ColorType:: RGB(16), DecodingBuffer::U16(ref mut buffer)) => {

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -427,15 +427,13 @@ impl<R: Read + Seek> Decoder<R> {
             }
             (ColorType::RGBA(16), DecodingBuffer::U16(ref mut buffer)) |
             (ColorType:: RGB(16), DecodingBuffer::U16(ref mut buffer)) => {
-                for datum in buffer[..bytes/2].iter_mut() {
-                    *datum = try!(reader.read_u16())
-                }
+                try!(reader.read_u16_into(&mut buffer[..bytes/2]));
                 bytes/2
             }
             (ColorType::Gray(16), DecodingBuffer::U16(ref mut buffer)) => {
-                for datum in buffer[..bytes/2].iter_mut() {
-                    *datum = try!(reader.read_u16());
-                    if self.photometric_interpretation == PhotometricInterpretation::WhiteIsZero {
+                try!(reader.read_u16_into(&mut buffer[..bytes/2]));
+                if self.photometric_interpretation == PhotometricInterpretation::WhiteIsZero {
+                    for datum in buffer[..bytes/2].iter_mut() {
                         *datum = 0xffff - *datum
                     }
                 }

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -28,6 +28,14 @@ pub trait EndianReader: Read {
         }
     }
 
+    #[inline(always)]
+    fn read_u16_into(&mut self, buffer: &mut [u16]) -> Result<(), io::Error> {
+        match self.byte_order() {
+            ByteOrder::LittleEndian => <Self as ReadBytesExt>::read_u16_into::<LittleEndian>(self, buffer),
+            ByteOrder::BigEndian => <Self as ReadBytesExt>::read_u16_into::<BigEndian>(self, buffer)
+        }
+    }
+
     /// Reads an u32
     #[inline(always)]
     fn read_u32(&mut self) -> Result<u32, io::Error> {


### PR DESCRIPTION
This pull request makes three changes:

 - It fixes an error where `Decoder::expand_strip` might not fill the whole buffer.
 - It greatly improves the performance for 16 bit images. (Reading many large tifs now takes minutes instead of hours.)
 - It removes the unsafe blocks in `Decoder::read_image` since I couldn't find any evidence that `ReadBytesExt::read_u16_into` guarantees that it doesn't read from the buffer. There isn't any significant performance impact due to zero initialization in this case.

Note that I think that there still are bugs in  `Decoder::read_image` when the image contains inconsistent information about the different sizes.