### PR TITLE
Use typed errors instead of strings

### DIFF
--- a/src/decoder/ifd.rs
+++ b/src/decoder/ifd.rs
@@ -4,7 +4,7 @@ use std::io::{self, Read, Seek};
 use std::collections::{HashMap};
 
 use super::stream::{ByteOrder, SmartReader, EndianReader};
-use ::{TiffError, TiffFormatError, TiffResult};
+use ::{TiffError, TiffFormatError, TiffUnsupportedError, TiffResult};
 
 use self::Value::{Unsigned, List, Rational};
 
@@ -86,7 +86,7 @@ pub enum Type {
 
 
 #[allow(unused_qualifications)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Value {
     //Signed(i32),
     Unsigned(u32),
@@ -194,7 +194,7 @@ impl Entry {
                 }
                 Ok(List(v))
             },
-            _ => Err(TiffError::UnsupportedError("Unsupported data type.".to_string()))
+            _ => Err(TiffError::UnsupportedError(TiffUnsupportedError::UnsupportedDataType))
         }
     }
 }

--- a/src/decoder/ifd.rs
+++ b/src/decoder/ifd.rs
@@ -4,7 +4,7 @@ use std::io::{self, Read, Seek};
 use std::collections::{HashMap};
 
 use super::stream::{ByteOrder, SmartReader, EndianReader};
-use ::{TiffError, TiffResult};
+use ::{TiffError, TiffFormatError, TiffResult};
 
 use self::Value::{Unsigned, List, Rational};
 
@@ -86,7 +86,7 @@ pub enum Type {
 
 
 #[allow(unused_qualifications)]
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Value {
     //Signed(i32),
     Unsigned(u32),
@@ -98,9 +98,7 @@ impl Value {
     pub fn into_u32(self) -> TiffResult<u32> {
         match self {
             Unsigned(val) => Ok(val),
-            val => Err(TiffError::FormatError(format!(
-                "Expected unsigned integer, {:?} found.", val
-            )))
+            val => Err(TiffError::FormatError(TiffFormatError::UnsignedIntegerExpected(val))),
         }
     }
     pub fn into_u32_vec(self) -> TiffResult<Vec<u32>> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,17 +2,43 @@ use std::error::Error;
 use std::fmt;
 use std::io;
 
+use decoder::ifd::{Tag, Value};
+
 /// Tiff error kinds.
 #[derive(Debug)]
 pub enum TiffError {
     /// The Image is not formatted properly
-    FormatError(String),
+    FormatError(TiffFormatError),
 
     /// The Decoder does not support this image format
     UnsupportedError(String),
 
     /// An I/O Error occurred while decoding the image
     IoError(io::Error),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TiffFormatError {
+    TiffSignatureNotFound,
+    TiffSignatureInvalid,
+    ImageFileDirectoryNotFound,
+    RequiredTagNotFound(Tag),
+    UnknownPredictor(u32),
+    UnsignedIntegerExpected(Value),
+}
+
+impl fmt::Display for TiffFormatError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        use self::TiffFormatError::*;
+        match *self {
+            TiffSignatureNotFound => write!(fmt, "TIFF signature not found."),
+            TiffSignatureInvalid => write!(fmt, "TIFF signature invalid."),
+            ImageFileDirectoryNotFound => write!(fmt, "Image file directory not found."),
+            RequiredTagNotFound(ref tag) => write!(fmt, "Required tag `{:?}` not found.", tag),
+            UnknownPredictor(ref predictor) => write!(fmt, "Unknown predictor “{}” encountered", predictor),
+            UnsignedIntegerExpected(ref val) => write!(fmt,  "Expected unsigned integer, {:?} found.", val),
+        }
+    }
 }
 
 impl fmt::Display for TiffError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,8 @@ use std::fmt;
 use std::io;
 
 use decoder::ifd::{Tag, Value};
+use decoder::{PhotometricInterpretation, CompressionMethod, PlanarConfiguration};
+use ColorType;
 
 /// Tiff error kinds.
 #[derive(Debug)]
@@ -11,13 +13,13 @@ pub enum TiffError {
     FormatError(TiffFormatError),
 
     /// The Decoder does not support this image format
-    UnsupportedError(String),
+    UnsupportedError(TiffUnsupportedError),
 
     /// An I/O Error occurred while decoding the image
     IoError(io::Error),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum TiffFormatError {
     TiffSignatureNotFound,
     TiffSignatureInvalid,
@@ -37,6 +39,40 @@ impl fmt::Display for TiffFormatError {
             RequiredTagNotFound(ref tag) => write!(fmt, "Required tag `{:?}` not found.", tag),
             UnknownPredictor(ref predictor) => write!(fmt, "Unknown predictor “{}” encountered", predictor),
             UnsignedIntegerExpected(ref val) => write!(fmt,  "Expected unsigned integer, {:?} found.", val),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum TiffUnsupportedError {
+    HorizontalPredictor(ColorType),
+    InterpretationWithBits(PhotometricInterpretation, Vec<u8>),
+    UnknownInterpretation,
+    UnknownCompressionMethod,
+    UnsupportedCompressionMethod(CompressionMethod),
+    UnsupportedSampleDepth(u8),
+    UnsupportedColorType(ColorType),
+    UnsupportedBitsPerChannel(u8),
+    UnsupportedPlanarConfig(Option<PlanarConfiguration>),
+    UnsupportedDataType,
+}
+
+impl fmt::Display for TiffUnsupportedError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        use self::TiffUnsupportedError::*;
+        match *self {
+            HorizontalPredictor(color_type) => write!(fmt, "Horizontal predictor for {:?} is unsupported.", color_type),
+            InterpretationWithBits(ref photometric_interpretation, ref bits_per_sample) => {
+                write!(fmt, "{:?} with {:?} bits per sample is unsupported", photometric_interpretation, bits_per_sample)
+            },
+            UnknownInterpretation => write!(fmt, "The image is using an unknown photometric interpretation."),
+            UnknownCompressionMethod => write!(fmt, "Unknown compression method."),
+            UnsupportedCompressionMethod(method) => write!(fmt, "Compression method {:?} is unsupported", method),
+            UnsupportedSampleDepth(samples) => write!(fmt, "{} samples per pixel is supported.", samples),
+            UnsupportedColorType(color_type) => write!(fmt, "Color type {:?} is unsupported", color_type),
+            UnsupportedBitsPerChannel(bits) => write!(fmt, "{} bits per channel not supported", bits),
+            UnsupportedPlanarConfig(config) => write!(fmt, "Unsupported planar configuration “{:?}”.", config),
+            UnsupportedDataType => write!(fmt, "Unsupported data type."),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ extern crate num_traits;
 pub mod decoder;
 mod error;
 
-pub use self::error::{TiffError, TiffResult};
+pub use self::error::{TiffError, TiffFormatError, TiffResult};
 
 /// An enumeration over supported color types and their bit depths
 #[derive(Copy, PartialEq, Eq, Debug, Clone, Hash)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ extern crate num_traits;
 pub mod decoder;
 mod error;
 
-pub use self::error::{TiffError, TiffFormatError, TiffResult};
+pub use self::error::{TiffError, TiffFormatError, TiffUnsupportedError, TiffResult};
 
 /// An enumeration over supported color types and their bit depths
 #[derive(Copy, PartialEq, Eq, Debug, Clone, Hash)]


### PR DESCRIPTION
Using strings as error types sidesteps everything that is great about Rusts error handling and is generally not very performance-friendly. Strings cannot be matched / destructured in case someone wants to catch a specific error case and it's generally bad practice to use strings as errors. 

This PR simply migrates from `String` to properly typed errors with proper `Display` impls.