### PR TITLE
Tiff encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ byteorder = "1.2"
 lzw = "0.10"
 num-derive = "0.2"
 num-traits = "0.2"
+
+[dev-dependencies]
+tempfile = "3.0"

--- a/src/decoder/ifd.rs
+++ b/src/decoder/ifd.rs
@@ -26,6 +26,12 @@ macro_rules! tags {
                     Tag::Unknown(n)
                 }
             }
+            pub fn to_u16(&self) -> u16 {
+                match self {
+                    $( Tag::$tag => $val, )*
+                    Tag::Unknown(n) => *n,
+                }
+            }
         }
     }
 }

--- a/src/encoder/colortype.rs
+++ b/src/encoder/colortype.rs
@@ -1,9 +1,11 @@
+use crate::decoder::PhotometricInterpretation;
+
 /// Trait for different colortypes that can be encoded.
 pub trait ColorType {
-    /// The type of each sample of thes colortype
+    /// The type of each sample of this colortype
     type Inner: super::TiffValue;
     /// The value of the tiff tag `PhotometricInterpretation`
-    const TIFF_VALUE: u8;
+    const TIFF_VALUE: PhotometricInterpretation;
     /// The value of the tiff tag `BitsPerSample`
     fn bits_per_sample() -> Vec<u16>;
 }
@@ -11,7 +13,7 @@ pub trait ColorType {
 pub struct Gray8;
 impl ColorType for Gray8 {
     type Inner = u8;
-    const TIFF_VALUE: u8 = 1;
+    const TIFF_VALUE: PhotometricInterpretation = PhotometricInterpretation::BlackIsZero;
     fn bits_per_sample() -> Vec<u16> {
         vec![8]
     }
@@ -20,7 +22,7 @@ impl ColorType for Gray8 {
 pub struct Gray16;
 impl ColorType for Gray16 {
     type Inner = u16;
-    const TIFF_VALUE: u8 = 1;
+    const TIFF_VALUE: PhotometricInterpretation = PhotometricInterpretation::BlackIsZero;
     fn bits_per_sample() -> Vec<u16> {
         vec![16]
     }
@@ -29,7 +31,7 @@ impl ColorType for Gray16 {
 pub struct RGB8;
 impl ColorType for RGB8 {
     type Inner = u8;
-    const TIFF_VALUE: u8 = 2;
+    const TIFF_VALUE: PhotometricInterpretation = PhotometricInterpretation::RGB;
     fn bits_per_sample() -> Vec<u16> {
         vec![8,8,8]
     }
@@ -38,7 +40,7 @@ impl ColorType for RGB8 {
 pub struct RGB16;
 impl ColorType for RGB16 {
     type Inner = u16;
-    const TIFF_VALUE: u8 = 2;
+    const TIFF_VALUE: PhotometricInterpretation = PhotometricInterpretation::RGB;
     fn bits_per_sample() -> Vec<u16> {
         vec![16,16,16]
     }
@@ -47,7 +49,7 @@ impl ColorType for RGB16 {
 pub struct RGBA8;
 impl ColorType for RGBA8 {
     type Inner = u8;
-    const TIFF_VALUE: u8 = 2;
+    const TIFF_VALUE: PhotometricInterpretation = PhotometricInterpretation::RGB;
     fn bits_per_sample() -> Vec<u16> {
         vec![8,8,8,8]
     }
@@ -56,7 +58,7 @@ impl ColorType for RGBA8 {
 pub struct RGBA16;
 impl ColorType for RGBA16 {
     type Inner = u16;
-    const TIFF_VALUE: u8 = 2;
+    const TIFF_VALUE: PhotometricInterpretation = PhotometricInterpretation::RGB;
     fn bits_per_sample() -> Vec<u16> {
         vec![16,16,16,16]
     }
@@ -65,7 +67,7 @@ impl ColorType for RGBA16 {
 pub struct CMYK8;
 impl ColorType for CMYK8 {
     type Inner = u8;
-    const TIFF_VALUE: u8 = 5;
+    const TIFF_VALUE: PhotometricInterpretation = PhotometricInterpretation::CMYK;
     fn bits_per_sample() -> Vec<u16> {
         vec![8,8,8,8]
     }

--- a/src/encoder/colortype.rs
+++ b/src/encoder/colortype.rs
@@ -1,0 +1,68 @@
+pub trait ColorType {
+    type Inner: super::TiffValue;
+    const TIFF_VALUE: u8;
+    fn bits_per_sample() -> Vec<u16>;
+}
+
+pub struct Grey8;
+impl ColorType for Grey8 {
+    type Inner = u8;
+    const TIFF_VALUE: u8 = 1;
+    fn bits_per_sample() -> Vec<u16> {
+        vec![8]
+    }
+}
+
+pub struct Grey16;
+impl ColorType for Grey16 {
+    type Inner = u16;
+    const TIFF_VALUE: u8 = 1;
+    fn bits_per_sample() -> Vec<u16> {
+        vec![16]
+    }
+}
+
+pub struct RGB8;
+impl ColorType for RGB8 {
+    type Inner = u8;
+    const TIFF_VALUE: u8 = 2;
+    fn bits_per_sample() -> Vec<u16> {
+        vec![8,8,8]
+    }
+}
+
+pub struct RGB16;
+impl ColorType for RGB16 {
+    type Inner = u16;
+    const TIFF_VALUE: u8 = 2;
+    fn bits_per_sample() -> Vec<u16> {
+        vec![16,16,16]
+    }
+}
+
+pub struct RGBA8;
+impl ColorType for RGBA8 {
+    type Inner = u8;
+    const TIFF_VALUE: u8 = 2;
+    fn bits_per_sample() -> Vec<u16> {
+        vec![8,8,8,8]
+    }
+}
+
+pub struct RGBA16;
+impl ColorType for RGBA16 {
+    type Inner = u16;
+    const TIFF_VALUE: u8 = 2;
+    fn bits_per_sample() -> Vec<u16> {
+        vec![16,16,16,16]
+    }
+}
+
+pub struct CMYK8;
+impl ColorType for CMYK8 {
+    type Inner = u8;
+    const TIFF_VALUE: u8 = 5;
+    fn bits_per_sample() -> Vec<u16> {
+        vec![8,8,8,8]
+    }
+}

--- a/src/encoder/colortype.rs
+++ b/src/encoder/colortype.rs
@@ -7,68 +7,54 @@ pub trait ColorType {
     /// The value of the tiff tag `PhotometricInterpretation`
     const TIFF_VALUE: PhotometricInterpretation;
     /// The value of the tiff tag `BitsPerSample`
-    fn bits_per_sample() -> Vec<u16>;
+    const BITS_PER_SAMPLE: &'static [u16];
 }
 
 pub struct Gray8;
 impl ColorType for Gray8 {
     type Inner = u8;
     const TIFF_VALUE: PhotometricInterpretation = PhotometricInterpretation::BlackIsZero;
-    fn bits_per_sample() -> Vec<u16> {
-        vec![8]
-    }
+    const BITS_PER_SAMPLE: &'static [u16] = &[8];
 }
 
 pub struct Gray16;
 impl ColorType for Gray16 {
     type Inner = u16;
     const TIFF_VALUE: PhotometricInterpretation = PhotometricInterpretation::BlackIsZero;
-    fn bits_per_sample() -> Vec<u16> {
-        vec![16]
-    }
+    const BITS_PER_SAMPLE: &'static [u16] = &[16];
 }
 
 pub struct RGB8;
 impl ColorType for RGB8 {
     type Inner = u8;
     const TIFF_VALUE: PhotometricInterpretation = PhotometricInterpretation::RGB;
-    fn bits_per_sample() -> Vec<u16> {
-        vec![8,8,8]
-    }
+    const BITS_PER_SAMPLE: &'static [u16] = &[8, 8, 8];
 }
 
 pub struct RGB16;
 impl ColorType for RGB16 {
     type Inner = u16;
     const TIFF_VALUE: PhotometricInterpretation = PhotometricInterpretation::RGB;
-    fn bits_per_sample() -> Vec<u16> {
-        vec![16,16,16]
-    }
+    const BITS_PER_SAMPLE: &'static [u16] = &[16, 16, 16];
 }
 
 pub struct RGBA8;
 impl ColorType for RGBA8 {
     type Inner = u8;
     const TIFF_VALUE: PhotometricInterpretation = PhotometricInterpretation::RGB;
-    fn bits_per_sample() -> Vec<u16> {
-        vec![8,8,8,8]
-    }
+    const BITS_PER_SAMPLE: &'static [u16] = &[8, 8, 8, 8];
 }
 
 pub struct RGBA16;
 impl ColorType for RGBA16 {
     type Inner = u16;
     const TIFF_VALUE: PhotometricInterpretation = PhotometricInterpretation::RGB;
-    fn bits_per_sample() -> Vec<u16> {
-        vec![16,16,16,16]
-    }
+    const BITS_PER_SAMPLE: &'static [u16] = &[16, 16, 16, 16];
 }
 
 pub struct CMYK8;
 impl ColorType for CMYK8 {
     type Inner = u8;
     const TIFF_VALUE: PhotometricInterpretation = PhotometricInterpretation::CMYK;
-    fn bits_per_sample() -> Vec<u16> {
-        vec![8,8,8,8]
-    }
+    const BITS_PER_SAMPLE: &'static [u16] = &[8, 8, 8, 8];
 }

--- a/src/encoder/colortype.rs
+++ b/src/encoder/colortype.rs
@@ -1,11 +1,15 @@
+/// Trait for different colortypes that can be encoded.
 pub trait ColorType {
+    /// The type of each sample of thes colortype
     type Inner: super::TiffValue;
+    /// The value of the tiff tag `PhotometricInterpretation`
     const TIFF_VALUE: u8;
+    /// The value of the tiff tag `BitsPerSample`
     fn bits_per_sample() -> Vec<u16>;
 }
 
-pub struct Grey8;
-impl ColorType for Grey8 {
+pub struct Gray8;
+impl ColorType for Gray8 {
     type Inner = u8;
     const TIFF_VALUE: u8 = 1;
     fn bits_per_sample() -> Vec<u16> {
@@ -13,8 +17,8 @@ impl ColorType for Grey8 {
     }
 }
 
-pub struct Grey16;
-impl ColorType for Grey16 {
+pub struct Gray16;
+impl ColorType for Gray16 {
     type Inner = u16;
     const TIFF_VALUE: u8 = 1;
     fn bits_per_sample() -> Vec<u16> {

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -6,7 +6,10 @@ use crate::decoder::ifd;
 use crate::error::{TiffResult, TiffFormatError, TiffError};
 
 mod writer;
+pub mod colortype;
+
 use self::writer::*;
+use self::colortype::*;
 
 pub struct Rational {
     pub n: u32,
@@ -117,29 +120,6 @@ impl TiffValue for str {
 }
 
 
-pub trait ColorType {
-    type Inner: TiffValue;
-    const TIFF_VALUE: u8;
-    fn bits_per_sample() -> Vec<u16>;
-}
-
-pub struct RGB8;
-impl ColorType for RGB8 {
-    type Inner = u8;
-    const TIFF_VALUE: u8 = 2;
-    fn bits_per_sample() -> Vec<u16> {
-        vec![8,8,8]
-    }
-}
-
-pub struct RGBA8;
-impl ColorType for RGBA8 {
-    type Inner = u8;
-    const TIFF_VALUE: u8 = 2;
-    fn bits_per_sample() -> Vec<u16> {
-        vec![8,8,8,8]
-    }
-}
 
 
 pub struct TiffEncoder<W> {

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -165,6 +165,19 @@ impl<W: Write + Seek> TiffEncoder<W> {
         let encoder = DirectoryEncoder::new(&mut self.writer)?;
         ImageEncoder::new(encoder, width, height)
     }
+
+    pub fn write_image<C: ColorType>(&mut self, width: u32, height: u32, data: &[C::Inner]) -> TiffResult<()> {
+        let encoder = DirectoryEncoder::new(&mut self.writer)?;
+        let mut image: ImageEncoder<W, C> = ImageEncoder::new(encoder, width, height).unwrap();
+
+        let mut idx = 0;
+        while image.next_strip_sample_count() > 0 {
+            let sample_count = image.next_strip_sample_count() as usize;
+            image.write_strip(&data[idx..idx+sample_count]).unwrap();
+            idx += sample_count;
+        }
+        image.finish()
+    }
 }
 
 pub struct DirectoryEncoder<'a, W> {

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -1,0 +1,264 @@
+mod writer;
+use self::writer::*;
+use std::io::{self, Write, Seek};
+use crate::decoder::ifd;
+use std::collections::{BTreeMap, HashMap};
+
+pub struct Rational {
+    pub n: u32,
+    pub d: u32,
+}
+
+pub trait IfdType {
+    type Inner;
+    fn byte_len() -> u32;
+    fn field_type() -> u16;
+    fn count(&self) -> u32;
+    fn write<W: Write>(&self, writer: &mut TiffWriter<W>) -> Result<(), io::Error>;
+}
+
+impl IfdType for [u8] {
+    type Inner = u8;
+    fn byte_len() -> u32 {
+        1
+    }
+    fn field_type() -> u16 {
+        1
+    }
+    fn count(&self) -> u32 {
+        self.len() as u32
+    }
+    fn write<W: Write>(&self, writer: &mut TiffWriter<W>) -> Result<(), io::Error> {
+        for x in self {
+            writer.write_u8(*x)?;
+        }
+        Ok(())
+    }
+}
+
+impl IfdType for [u16] {
+    type Inner = u16;
+    fn byte_len() -> u32 {
+        2
+    }
+    fn field_type() -> u16 {
+        3
+    }
+    fn count(&self) -> u32 {
+        self.len() as u32
+    }
+    fn write<W: Write>(&self, writer: &mut TiffWriter<W>) -> Result<(), io::Error> {
+        for x in self {
+            writer.write_u16(*x)?;
+        }
+        Ok(())
+    }
+}
+
+impl IfdType for [u32] {
+    type Inner = u32;
+    fn byte_len() -> u32 {
+        4
+    }
+    fn field_type() -> u16 {
+        4
+    }
+    fn count(&self) -> u32 {
+        self.len() as u32
+    }
+    fn write<W: Write>(&self, writer: &mut TiffWriter<W>) -> Result<(), io::Error> {
+        for x in self {
+            writer.write_u32(*x)?;
+        }
+        Ok(())
+    }
+}
+
+impl IfdType for [Rational] {
+    type Inner = Rational;
+    fn byte_len() -> u32 {
+        8
+    }
+    fn field_type() -> u16 {
+        5
+    }
+    fn count(&self) -> u32 {
+        self.len() as u32
+    }
+    fn write<W: Write>(&self, writer: &mut TiffWriter<W>) -> Result<(), io::Error> {
+        for x in self {
+            writer.write_u32(x.n)?;
+            writer.write_u32(x.d)?;
+        }
+        Ok(())
+    }
+}
+
+impl IfdType for [i8] {
+    type Inner = i8;
+    fn byte_len() -> u32 {
+        1
+    }
+    fn field_type() -> u16 {
+        6
+    }
+    fn count(&self) -> u32 {
+        self.len() as u32
+    }
+    fn write<W: Write>(&self, writer: &mut TiffWriter<W>) -> Result<(), io::Error> {
+        for x in self {
+            writer.write_u8(*x as u8)?;
+        }
+        Ok(())
+    }
+}
+
+impl IfdType for str {
+    type Inner = u8;
+    fn byte_len() -> u32 {
+        1
+    }
+    fn field_type() -> u16 {
+        2
+    }
+    fn count(&self) -> u32 {
+        self.len() as u32
+    }
+    fn write<W: Write>(&self, writer: &mut TiffWriter<W>) -> Result<(), io::Error> {
+        for x in self.chars() {
+            if x.is_ascii() {
+                writer.write_u8(x as u8)?;
+            }
+        }
+        writer.write_u8(0)?;
+        Ok(())
+    }
+}
+
+pub struct TiffEncoder<W> {
+    writer: TiffWriter<W>,
+    // Sort tags by ascending order
+    ifd: BTreeMap<u16, (u16, u32, Vec<u8>)>,
+    ifd_offsets: HashMap<u16, u32>,
+    strip_number: u32,
+}
+
+impl<W: Write + Seek> TiffEncoder<W> {
+    pub fn new_le(writer: W) -> TiffEncoder<W> {
+        TiffEncoder {
+            writer: TiffWriter::new_le(writer),
+            ifd: BTreeMap::new(),
+            ifd_offsets: HashMap::new(),
+            strip_number: 0,
+        }
+    }
+
+    pub fn new_be(writer: W) -> TiffEncoder<W> {
+        TiffEncoder {
+            writer: TiffWriter::new_be(writer),
+            ifd: BTreeMap::new(),
+            ifd_offsets: HashMap::new(),
+            strip_number: 0,
+        }
+    }
+
+    pub fn write_header(&mut self) -> Result<(), io::Error> {
+        match self.writer.byte_order() {
+            ByteOrder::LittleEndian => self.writer.write_u16(0x4949)?,
+            ByteOrder::BigEndian => self.writer.write_u16(0x4d4d)?,
+        };
+        self.writer.write_u16(42)?;
+
+        Ok(())
+    }
+
+    pub fn new_ifd(&mut self) -> Result<(), io::Error> {
+        self.writer.pad_word_boundary()?;
+        let offset = self.writer.offset();
+        self.writer.write_u32(offset + 4)?;
+
+        self.ifd = BTreeMap::new();
+
+        Ok(())
+    }
+
+    pub fn new_ifd_entry<T: IfdType + ?Sized>(&mut self, tag: ifd::Tag, value: &T) {
+        let mut bytes: Vec<u8> = Vec::new();
+        {
+            let mut writer = TiffWriter::new(&mut bytes, self.writer.byte_order());
+            value.write(&mut writer).unwrap();
+        }
+        self.ifd.insert(tag.to_u16(), (<T>::field_type(), value.count(), bytes));
+    }
+
+    pub fn finish_ifd(&mut self) -> Result<(), io::Error> {
+        self.ifd_offsets = HashMap::new();
+        self.writer.write_u16(self.ifd.len() as u16)?;
+
+        let mut value_offset = self.writer.offset() + self.ifd.len() as u32 * 12 + 4;
+
+        {
+            let mut ifd_values = Vec::new();
+
+            for (tag, (type_, count, bytes)) in &self.ifd {
+                self.writer.write_u16(*tag)?;
+                self.writer.write_u16(*type_)?;
+                self.writer.write_u32(*count)?;
+                if bytes.len() <= 4 {
+                    self.ifd_offsets.insert(*tag, self.writer.offset());
+                    self.writer.write_bytes(bytes)?;
+                    for _ in 0..4 - bytes.len() {
+                        self.writer.write_u8(0)?;
+                    }
+                }
+                else {
+                    self.ifd_offsets.insert(*tag, value_offset);
+                    self.writer.write_u32(value_offset)?;
+                    ifd_values.push(bytes);
+                    value_offset += bytes.len() as u32;
+                }
+            }
+
+            self.writer.write_u32(0)?;
+
+            for value in ifd_values {
+                self.writer.write_bytes(value)?;
+            }
+        }
+
+        self.ifd = BTreeMap::new();
+
+        Ok(())
+    }
+
+    pub fn update_ifd_value<T: IfdType + ?Sized>(&mut self, tag: ifd::Tag, idx: u32, value: &T) -> Result<(), io::Error> {
+        if let Some(off) = self.ifd_offsets.get(&tag.to_u16()) {
+            let curr_offset = self.writer.offset();
+            self.writer.too_offset(off + idx * <T>::byte_len())?;
+            value.write(&mut self.writer)?;
+            self.writer.too_offset(curr_offset)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn write_strip(&mut self, strip_value: &[u8]) -> Result<(), io::Error> {
+        let offset = self.writer.offset();
+        self.writer.write_bytes(strip_value)?;
+
+        let n = self.strip_number;
+
+        self.update_ifd_value::<[u32]>(ifd::Tag::StripOffsets, n, &[offset])?;
+        self.update_ifd_value::<[u32]>(ifd::Tag::StripByteCounts, n, &[strip_value.len() as u32])?;
+
+        Ok(())
+    }
+}
+
+pub struct IfdEncoder<'a, W> {
+    tiff_encoder: &'a mut TiffEncoder<W>,
+}
+
+pub struct ImageEncoder<'a, W> {
+    tiff_encoder: &'a mut TiffEncoder<W>,
+}

--- a/src/encoder/writer.rs
+++ b/src/encoder/writer.rs
@@ -1,48 +1,51 @@
 use std::io::{self, Write, Seek, SeekFrom};
-use byteorder::{WriteBytesExt, BigEndian, LittleEndian};
+use byteorder::{ByteOrder, WriteBytesExt, BigEndian, LittleEndian, NativeEndian};
+use crate::error::TiffResult;
 
-/// Byte order of the TIFF file.
-#[derive(Clone, Copy, Debug)]
-pub enum ByteOrder {
-    /// little endian byte order
-    LittleEndian,
-    /// big endian byte order
-    BigEndian
+pub trait TiffByteOrder: ByteOrder {
+    fn write_header<W: Write>(writer: &mut TiffWriter<W>) -> TiffResult<()>;
+}
+
+impl TiffByteOrder for LittleEndian {
+    fn write_header<W: Write>(writer: &mut TiffWriter<W>) -> TiffResult<()> {
+        writer.writer.write_u16::<LittleEndian>(0x4949)?;
+        writer.writer.write_u16::<LittleEndian>(42)?;
+        writer.offset += 4;
+
+        Ok(())
+    }
+}
+
+impl TiffByteOrder for BigEndian {
+    fn write_header<W: Write>(writer: &mut TiffWriter<W>) -> TiffResult<()> {
+        writer.writer.write_u16::<BigEndian>(0x4d4d)?;
+        writer.writer.write_u16::<BigEndian>(42)?;
+        writer.offset += 4;
+
+        Ok(())
+    }
 }
 
 pub struct TiffWriter<W> {
     writer: W,
-    byte_order: ByteOrder,
-    offset: u32,
+    offset: u64,
 }
 
 impl<W: Write> TiffWriter<W> {
-    pub fn new(writer: W, byte_order: ByteOrder) -> Self {
+    pub fn new(writer: W) -> Self {
         Self {
             writer,
-            byte_order,
             offset: 0,
         }
     }
-    pub fn new_le(writer: W) -> Self {
-        Self::new(writer, ByteOrder::LittleEndian)
-    }
 
-    pub fn new_be(writer: W) -> Self {
-        Self::new(writer, ByteOrder::BigEndian)
-    }
-
-    pub fn byte_order(&self) -> ByteOrder {
-        self.byte_order
-    }
-
-    pub fn offset(&self) -> u32 {
+    pub fn offset(&self) -> u64 {
         self.offset
     }
 
     pub fn write_bytes(&mut self, bytes: &[u8]) -> Result<(), io::Error> {
         self.writer.write_all(bytes)?;
-        self.offset += bytes.len() as u32;
+        self.offset += bytes.len() as u64;
         Ok(())
     }
 
@@ -53,23 +56,22 @@ impl<W: Write> TiffWriter<W> {
     }
 
     pub fn write_u16(&mut self, n: u16) -> Result<(), io::Error> {
-        match self.byte_order {
-            ByteOrder::LittleEndian => self.writer.write_u16::<LittleEndian>(n),
-            ByteOrder::BigEndian => self.writer.write_u16::<BigEndian>(n),
-        }?;
-
+        self.writer.write_u16::<NativeEndian>(n)?;
         self.offset += 2;
 
         Ok(())
     }
 
     pub fn write_u32(&mut self, n: u32) -> Result<(), io::Error> {
-        match self.byte_order {
-            ByteOrder::LittleEndian => self.writer.write_u32::<LittleEndian>(n),
-            ByteOrder::BigEndian => self.writer.write_u32::<BigEndian>(n),
-        }?;
-        
+        self.writer.write_u32::<NativeEndian>(n)?;
         self.offset += 4;
+
+        Ok(())
+    }
+
+    pub fn write_u64(&mut self, n: u64) -> Result<(), io::Error> {
+        self.writer.write_u64::<NativeEndian>(n)?;
+        self.offset += 8;
 
         Ok(())
     }
@@ -84,7 +86,7 @@ impl<W: Write> TiffWriter<W> {
 }
 
 impl<W: Seek> TiffWriter<W> {
-    pub fn too_offset(&mut self, offset: u32) -> Result<(), io::Error> {
+    pub fn goto_offset(&mut self, offset: u64) -> Result<(), io::Error> {
         self.offset = offset;
         self.writer.seek(SeekFrom::Start(offset as u64))?;
         Ok(())

--- a/src/encoder/writer.rs
+++ b/src/encoder/writer.rs
@@ -77,8 +77,10 @@ impl<W: Write> TiffWriter<W> {
     }
 
     pub fn pad_word_boundary(&mut self) -> Result<(), io::Error> {
-        while self.offset % 4 != 0 {
-            self.writer.write_u8(0)?;
+        if self.offset % 4 != 0 {
+            let padding = [0, 0, 0];
+            let padd_len = 4 - (self.offset % 4);
+            self.writer.write_all(&padding[..padd_len as usize])?;
         }
     
         Ok(())

--- a/src/encoder/writer.rs
+++ b/src/encoder/writer.rs
@@ -1,0 +1,92 @@
+use std::io::{self, Write, Seek, SeekFrom};
+use byteorder::{WriteBytesExt, BigEndian, LittleEndian};
+
+/// Byte order of the TIFF file.
+#[derive(Clone, Copy, Debug)]
+pub enum ByteOrder {
+    /// little endian byte order
+    LittleEndian,
+    /// big endian byte order
+    BigEndian
+}
+
+pub struct TiffWriter<W> {
+    writer: W,
+    byte_order: ByteOrder,
+    offset: u32,
+}
+
+impl<W: Write> TiffWriter<W> {
+    pub fn new(writer: W, byte_order: ByteOrder) -> Self {
+        Self {
+            writer,
+            byte_order,
+            offset: 0,
+        }
+    }
+    pub fn new_le(writer: W) -> Self {
+        Self::new(writer, ByteOrder::LittleEndian)
+    }
+
+    pub fn new_be(writer: W) -> Self {
+        Self::new(writer, ByteOrder::BigEndian)
+    }
+
+    pub fn byte_order(&self) -> ByteOrder {
+        self.byte_order
+    }
+
+    pub fn offset(&self) -> u32 {
+        self.offset
+    }
+
+    pub fn write_bytes(&mut self, bytes: &[u8]) -> Result<(), io::Error> {
+        self.writer.write_all(bytes)?;
+        self.offset += bytes.len() as u32;
+        Ok(())
+    }
+
+    pub fn write_u8(&mut self, n: u8) -> Result<(), io::Error> {
+        self.writer.write_u8(n)?;
+        self.offset += 1;
+        Ok(())
+    }
+
+    pub fn write_u16(&mut self, n: u16) -> Result<(), io::Error> {
+        match self.byte_order {
+            ByteOrder::LittleEndian => self.writer.write_u16::<LittleEndian>(n),
+            ByteOrder::BigEndian => self.writer.write_u16::<BigEndian>(n),
+        }?;
+
+        self.offset += 2;
+
+        Ok(())
+    }
+
+    pub fn write_u32(&mut self, n: u32) -> Result<(), io::Error> {
+        match self.byte_order {
+            ByteOrder::LittleEndian => self.writer.write_u32::<LittleEndian>(n),
+            ByteOrder::BigEndian => self.writer.write_u32::<BigEndian>(n),
+        }?;
+        
+        self.offset += 4;
+
+        Ok(())
+    }
+
+    pub fn pad_word_boundary(&mut self) -> Result<(), io::Error> {
+        while self.offset % 4 != 0 {
+            self.writer.write_u8(0)?;
+        }
+    
+        Ok(())
+    }
+}
+
+impl<W: Seek> TiffWriter<W> {
+    pub fn too_offset(&mut self, offset: u32) -> Result<(), io::Error> {
+        self.offset = offset;
+        self.writer.seek(SeekFrom::Start(offset as u64))?;
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ extern crate lzw;
 extern crate num_traits;
 
 pub mod decoder;
+pub mod encoder;
 mod error;
 
 pub use self::error::{TiffError, TiffFormatError, TiffUnsupportedError, TiffResult};

--- a/tests/encode_images.rs
+++ b/tests/encode_images.rs
@@ -1,0 +1,58 @@
+extern crate tiff;
+
+use tiff::ColorType;
+use tiff::decoder::{Decoder, DecodingResult, ifd::Tag, ifd::Value};
+use tiff::encoder::{TiffEncoder, Rational};
+
+use std::fs::File;
+
+
+#[test]
+fn encode_decode() {
+    let mut image_data = Vec::new();
+    for x in 0..100 {
+        for y in 0..100u8 {
+            let val = x + y;
+            image_data.push(val);
+            image_data.push(val);
+            image_data.push(val);
+        }
+    }
+    {
+        let file = std::fs::File::create("test.tiff").unwrap();
+        let mut tiff = TiffEncoder::new_le(file);
+
+        tiff.write_header().unwrap();
+
+        tiff.new_ifd().unwrap();
+        tiff.new_ifd_entry(Tag::ImageWidth, &[100u32][..]);
+        tiff.new_ifd_entry(Tag::ImageLength, &[100u32][..]);
+        tiff.new_ifd_entry(Tag::BitsPerSample, &[8u16,8,8][..]);
+        tiff.new_ifd_entry(Tag::Compression, &[1u16][..]);
+        tiff.new_ifd_entry(Tag::PhotometricInterpretation, &[2u16][..]);
+        tiff.new_ifd_entry(Tag::StripOffsets, &[0u32][..]);
+        tiff.new_ifd_entry(Tag::SamplesPerPixel, &[3u16][..]);
+        tiff.new_ifd_entry(Tag::RowsPerStrip, &[100u32][..]);
+        tiff.new_ifd_entry(Tag::StripByteCounts, &[0u32][..]);
+        tiff.new_ifd_entry(Tag::XResolution, &[Rational {n: 1, d: 1}][..]);
+        tiff.new_ifd_entry(Tag::YResolution, &[Rational {n: 1, d: 1}][..]);
+        tiff.new_ifd_entry(Tag::ResolutionUnit, &[1u16][..]);
+        tiff.finish_ifd().unwrap();
+
+        tiff.write_strip(&image_data).unwrap();
+    }
+    {
+        let file = File::open("test.tiff").unwrap();
+        let mut decoder = Decoder::new(file).unwrap();
+        assert_eq!(decoder.colortype().unwrap(), ColorType::RGB(8));
+        assert_eq!(decoder.dimensions().unwrap(), (100, 100));
+        if let DecodingResult::U8(img_res) = decoder.read_image().unwrap() {
+            assert_eq!(image_data, img_res);
+        }
+        else {
+            panic!("Wrong data type");
+        }
+    }
+    
+    std::fs::remove_file("test.tiff").unwrap();
+}

--- a/tests/encode_images.rs
+++ b/tests/encode_images.rs
@@ -22,15 +22,7 @@ fn encode_decode() {
     {
         let mut tiff = TiffEncoder::new(&mut file).unwrap();
 
-        let mut image = tiff.new_image::<RGB8>(100, 100).unwrap();
-    
-        let mut idx = 0;
-        while image.next_strip_sample_count() > 0 {
-            let sample_count = image.next_strip_sample_count() as usize;
-            image.write_strip(&image_data[idx..idx+sample_count]).unwrap();
-            idx += sample_count;
-        }
-        image.finish().unwrap();
+        tiff.write_image::<RGB8>(100, 100, &image_data).unwrap();
     }
     {
         file.seek(SeekFrom::Start(0)).unwrap();

--- a/tests/encode_images.rs
+++ b/tests/encode_images.rs
@@ -57,7 +57,7 @@ fn test_gray_u8_roundtrip()
         let mut tiff = TiffEncoder::new(&mut file).unwrap();
     
         let (width, height) = decoder.dimensions().unwrap();
-        tiff.write_image::<colortype::Grey8>(width, height, &image_data).unwrap();
+        tiff.write_image::<colortype::Gray8>(width, height, &image_data).unwrap();
     }
     file.seek(SeekFrom::Start(0)).unwrap();
     {
@@ -119,7 +119,7 @@ fn test_gray_u16_roundtrip()
         let mut tiff = TiffEncoder::new(&mut file).unwrap();
     
         let (width, height) = decoder.dimensions().unwrap();
-        tiff.write_image::<colortype::Grey16>(width, height, &image_data).unwrap();
+        tiff.write_image::<colortype::Gray16>(width, height, &image_data).unwrap();
     }
     file.seek(SeekFrom::Start(0)).unwrap();
     {

--- a/tests/encode_images.rs
+++ b/tests/encode_images.rs
@@ -46,51 +46,122 @@ fn test_gray_u8_roundtrip()
     let img_file = File::open("./tests/images/minisblack-1c-8b.tiff").expect("Cannot find test image!");
     let mut decoder = Decoder::new(img_file).expect("Cannot create decoder");
     assert_eq!(decoder.colortype().unwrap(), ColorType::Gray(8));
-    let img_res = decoder.read_image();
-    assert!(img_res.is_ok());
+
+    let image_data = match decoder.read_image().unwrap() {
+        DecodingResult::U8(res) => res,
+        _ => panic!("Wrong data type"),
+    };
+
+    let mut file = tempfile::tempfile().unwrap();
+    {
+        let mut tiff = TiffEncoder::new(&mut file).unwrap();
+    
+        let (width, height) = decoder.dimensions().unwrap();
+        tiff.write_image::<colortype::Grey8>(width, height, &image_data).unwrap();
+    }
+    file.seek(SeekFrom::Start(0)).unwrap();
+    {
+        let mut decoder = Decoder::new(&mut file).unwrap();
+        if let DecodingResult::U8(img_res) = decoder.read_image().unwrap() {
+            assert_eq!(image_data, img_res);
+        }
+        else {
+            panic!("Wrong data type");
+        }
+    }
 }
 
 #[test]
-fn test_rgb_u8()
+fn test_rgb_u8_roundtrip()
 {
     let img_file = File::open("./tests/images/rgb-3c-8b.tiff").expect("Cannot find test image!");
     let mut decoder = Decoder::new(img_file).expect("Cannot create decoder");
     assert_eq!(decoder.colortype().unwrap(), ColorType::RGB(8));
-    let img_res = decoder.read_image();
+
+    let image_data = match decoder.read_image().unwrap() {
+        DecodingResult::U8(res) => res,
+        _ => panic!("Wrong data type"),
+    };
 
     let mut file = tempfile::tempfile().unwrap();
-    let mut tiff = TiffEncoder::new(&mut file).unwrap();
-
-    tiff.write_image::<colortype::RGB8>(100, 100, &image_data).unwrap();
-    file.seek(SeekFrom::Start(0)).unwrap();
-
-    let mut decoder = Decoder::new(&mut file).unwrap();
-    assert_eq!(decoder.colortype().unwrap(), ColorType::RGB(8));
-    assert_eq!(decoder.dimensions().unwrap(), (100, 100));
-    if let DecodingResult::U8(img_res) = decoder.read_image().unwrap() {
-        assert_eq!(image_data, img_res);
+    {
+        let mut tiff = TiffEncoder::new(&mut file).unwrap();
+    
+        let (width, height) = decoder.dimensions().unwrap();
+        tiff.write_image::<colortype::RGB8>(width, height, &image_data).unwrap();
     }
-    else {
-        panic!("Wrong data type");
+    file.seek(SeekFrom::Start(0)).unwrap();
+    {
+        let mut decoder = Decoder::new(&mut file).unwrap();
+        if let DecodingResult::U8(img_res) = decoder.read_image().unwrap() {
+            assert_eq!(image_data, img_res);
+        }
+        else {
+            panic!("Wrong data type");
+        }
     }
 }
 
 #[test]
-fn test_gray_u16()
+fn test_gray_u16_roundtrip()
 {
     let img_file = File::open("./tests/images/minisblack-1c-16b.tiff").expect("Cannot find test image!");
     let mut decoder = Decoder::new(img_file).expect("Cannot create decoder");
     assert_eq!(decoder.colortype().unwrap(), ColorType::Gray(16));
-    let img_res = decoder.read_image();
-    assert!(img_res.is_ok());
+
+    let image_data = match decoder.read_image().unwrap() {
+        DecodingResult::U16(res) => res,
+        _ => panic!("Wrong data type"),
+    };
+
+    let mut file = tempfile::tempfile().unwrap();
+    {
+        let mut tiff = TiffEncoder::new(&mut file).unwrap();
+    
+        let (width, height) = decoder.dimensions().unwrap();
+        tiff.write_image::<colortype::Grey16>(width, height, &image_data).unwrap();
+    }
+    file.seek(SeekFrom::Start(0)).unwrap();
+    {
+        let mut decoder = Decoder::new(&mut file).unwrap();
+        if let DecodingResult::U16(img_res) = decoder.read_image().unwrap() {
+            assert_eq!(image_data, img_res);
+        }
+        else {
+            panic!("Wrong data type");
+        }
+    }
 }
 
 #[test]
-fn test_rgb_u16()
+fn test_rgb_u16_roundtrip()
 {
     let img_file = File::open("./tests/images/rgb-3c-16b.tiff").expect("Cannot find test image!");
     let mut decoder = Decoder::new(img_file).expect("Cannot create decoder");
     assert_eq!(decoder.colortype().unwrap(), ColorType::RGB(16));
     let img_res = decoder.read_image();
     assert!(img_res.is_ok());
+
+    let image_data = match decoder.read_image().unwrap() {
+        DecodingResult::U16(res) => res,
+        _ => panic!("Wrong data type"),
+    };
+
+    let mut file = tempfile::tempfile().unwrap();
+    {
+        let mut tiff = TiffEncoder::new(&mut file).unwrap();
+    
+        let (width, height) = decoder.dimensions().unwrap();
+        tiff.write_image::<colortype::RGB16>(width, height, &image_data).unwrap();
+    }
+    file.seek(SeekFrom::Start(0)).unwrap();
+    {
+        let mut decoder = Decoder::new(&mut file).unwrap();
+        if let DecodingResult::U16(img_res) = decoder.read_image().unwrap() {
+            assert_eq!(image_data, img_res);
+        }
+        else {
+            panic!("Wrong data type");
+        }
+    }
 }


### PR DESCRIPTION
This is a very much WIP implementation of tiff encoding. I believe that it is correct and can handle most cases, however the api is currently not very ergonomic or safe. It also lacks built-inn compression, however that kind of requires https://github.com/nwin/lzw/pull/1. 

Currently the api looks something like this, but I would very much like to improve it. 

```rust
let file = std::fs::File::create("test.tiff").unwrap();
let mut tiff = TiffEncoder::new_le(file);

tiff.write_header().unwrap();

tiff.new_ifd().unwrap();
tiff.new_ifd_entry(Tag::ImageWidth, &[100u32][..]);
tiff.new_ifd_entry(Tag::ImageLength, &[100u32][..]);
tiff.new_ifd_entry(Tag::BitsPerSample, &[8u16,8,8][..]);
tiff.new_ifd_entry(Tag::Compression, &[1u16][..]);
tiff.new_ifd_entry(Tag::PhotometricInterpretation, &[2u16][..]);
tiff.new_ifd_entry(Tag::SamplesPerPixel, &[3u16][..]);
tiff.new_ifd_entry(Tag::RowsPerStrip, &[100u32][..]);
tiff.new_ifd_entry(Tag::XResolution, &[Rational {n: 1, d: 1}][..]);
tiff.new_ifd_entry(Tag::YResolution, &[Rational {n: 1, d: 1}][..]);
tiff.new_ifd_entry(Tag::ResolutionUnit, &[1u16][..]);
// The two following tags are overwritten by `write_strip`
tiff.new_ifd_entry(Tag::StripOffsets, &[0u32][..]);
tiff.new_ifd_entry(Tag::StripByteCounts, &[0u32][..]);
tiff.finish_ifd().unwrap();

tiff.write_strip(&image_data).unwrap();
```